### PR TITLE
fixing nock tests.

### DIFF
--- a/test/search.js
+++ b/test/search.js
@@ -14,21 +14,24 @@ describe('the easy way', () => {
 })
 
 describe('nock it out', () => {
-  nock('http://www.imdb.com')
-    .get('/find')
-    .reply(200, `
-      <div class='findSection'>
-        <table class="findList">
-          <tr> <td class="result_text">Rocky</td> </tr>
-          <tr> <td class="result_text">Rocky II</td> </tr>
-        </table>
-      </div>
-      <div class='findSection'>
-        <table class="findList">
-          <tr> <td class="result_text">do not return</td> </tr>
-        </table>
-      </div>
-    `)
+  beforeEach(function() {
+    nock('http://www.imdb.com')
+      .get('/find')
+      .query(true)
+      .reply(200, `
+        <div class='findSection'>
+          <table class="findList">
+            <tr> <td class="result_text">Rocky</td> </tr>
+            <tr> <td class="result_text">Rocky II</td> </tr>
+          </table>
+        </div>
+        <div class='findSection'>
+          <table class="findList">
+            <tr> <td class="result_text">do not return</td> </tr>
+          </table>
+        </div>
+      `)
+    })
 
   it('can find rocky', (done) => {
     searchIMDB('rocky', (err, result) => {


### PR DESCRIPTION
It turns out that you need to specify the query string with nock. You
can do this with the `.query()` method by passing in the literal string,
and object with the query params, or just the boolean literal `true` to
indicate that there should be a query string but you don't care what it
is.

Also the nock need to happen before the test where it's being used, so
you have to make the call insite the `it` callback or in a `beforeEach`
in the same describe block as your `it`